### PR TITLE
Oracle学習教材カラーテーマ統一

### DIFF
--- a/docs/guide/database/oracle/oracle-learning-material-1.html
+++ b/docs/guide/database/oracle/oracle-learning-material-1.html
@@ -14,7 +14,7 @@
             padding-top: 56px;
         }
         .navbar {
-            background-color: #ff5722;
+            background-color: #1976d2;
         }
         .sidebar {
             position: sticky;
@@ -23,14 +23,14 @@
             overflow-y: auto;
         }
         .chapter-title {
-            color: #ff5722;
+            color: #1976d2;
             margin-top: 1.5rem;
             margin-bottom: 1rem;
-            border-bottom: 2px solid #ff5722;
+            border-bottom: 2px solid #1976d2;
             padding-bottom: 0.5rem;
         }
         .section-title {
-            color: #ff7043;
+            color: #42a5f5;
             margin-top: 1.2rem;
             margin-bottom: 0.8rem;
         }
@@ -45,11 +45,11 @@
             overflow-x: auto;
         }
         .quiz-container {
-            background-color: #fff3e0;
+            background-color: #e1f5fe;
             border-radius: 8px;
             padding: 1.5rem;
             margin: 1.5rem 0;
-            border-left: 4px solid #ff5722;
+            border-left: 4px solid #1976d2;
         }
         .exercise-container {
             background-color: #f3e5f5;
@@ -73,7 +73,7 @@
             border-left: 4px solid #f44336;
         }
         .nav-link.active {
-            background-color: #ff5722 !important;
+            background-color: #1976d2 !important;
             color: white !important;
         }
     </style>

--- a/docs/guide/database/oracle/oracle-learning-material-2.html
+++ b/docs/guide/database/oracle/oracle-learning-material-2.html
@@ -14,7 +14,7 @@
             padding-top: 56px;
         }
         .navbar {
-            background-color: #ff5722;
+            background-color: #1976d2;
         }
         .sidebar {
             position: sticky;
@@ -23,14 +23,14 @@
             overflow-y: auto;
         }
         .chapter-title {
-            color: #ff5722;
+            color: #1976d2;
             margin-top: 1.5rem;
             margin-bottom: 1rem;
-            border-bottom: 2px solid #ff5722;
+            border-bottom: 2px solid #1976d2;
             padding-bottom: 0.5rem;
         }
         .section-title {
-            color: #ff7043;
+            color: #42a5f5;
             margin-top: 1.2rem;
             margin-bottom: 0.8rem;
         }
@@ -45,11 +45,11 @@
             overflow-x: auto;
         }
         .quiz-container {
-            background-color: #fff3e0;
+            background-color: #e1f5fe;
             border-radius: 8px;
             padding: 1.5rem;
             margin: 1.5rem 0;
-            border-left: 4px solid #ff5722;
+            border-left: 4px solid #1976d2;
         }
         .exercise-container {
             background-color: #f3e5f5;
@@ -73,7 +73,7 @@
             border-left: 4px solid #f44336;
         }
         .nav-link.active {
-            background-color: #ff5722 !important;
+            background-color: #1976d2 !important;
             color: white !important;
         }
     </style>

--- a/docs/guide/database/oracle/oracle-learning-material-3.html
+++ b/docs/guide/database/oracle/oracle-learning-material-3.html
@@ -14,7 +14,7 @@
             padding-top: 56px;
         }
         .navbar {
-            background-color: #ff5722;
+            background-color: #1976d2;
         }
         .sidebar {
             position: sticky;
@@ -23,14 +23,14 @@
             overflow-y: auto;
         }
         .chapter-title {
-            color: #ff5722;
+            color: #1976d2;
             margin-top: 1.5rem;
             margin-bottom: 1rem;
-            border-bottom: 2px solid #ff5722;
+            border-bottom: 2px solid #1976d2;
             padding-bottom: 0.5rem;
         }
         .section-title {
-            color: #ff7043;
+            color: #42a5f5;
             margin-top: 1.2rem;
             margin-bottom: 0.8rem;
         }
@@ -45,11 +45,11 @@
             overflow-x: auto;
         }
         .quiz-container {
-            background-color: #fff3e0;
+            background-color: #e1f5fe;
             border-radius: 8px;
             padding: 1.5rem;
             margin: 1.5rem 0;
-            border-left: 4px solid #ff5722;
+            border-left: 4px solid #1976d2;
         }
         .exercise-container {
             background-color: #f3e5f5;
@@ -73,7 +73,7 @@
             border-left: 4px solid #f44336;
         }
         .nav-link.active {
-            background-color: #ff5722 !important;
+            background-color: #1976d2 !important;
             color: white !important;
         }
     </style>

--- a/docs/guide/database/oracle/oracle-learning-material-4.html
+++ b/docs/guide/database/oracle/oracle-learning-material-4.html
@@ -14,7 +14,7 @@
             padding-top: 56px;
         }
         .navbar {
-            background-color: #ff5722;
+            background-color: #1976d2;
         }
         .sidebar {
             position: sticky;
@@ -23,14 +23,14 @@
             overflow-y: auto;
         }
         .chapter-title {
-            color: #ff5722;
+            color: #1976d2;
             margin-top: 1.5rem;
             margin-bottom: 1rem;
-            border-bottom: 2px solid #ff5722;
+            border-bottom: 2px solid #1976d2;
             padding-bottom: 0.5rem;
         }
         .section-title {
-            color: #ff7043;
+            color: #42a5f5;
             margin-top: 1.2rem;
             margin-bottom: 0.8rem;
         }
@@ -45,11 +45,11 @@
             overflow-x: auto;
         }
         .quiz-container {
-            background-color: #fff3e0;
+            background-color: #e1f5fe;
             border-radius: 8px;
             padding: 1.5rem;
             margin: 1.5rem 0;
-            border-left: 4px solid #ff5722;
+            border-left: 4px solid #1976d2;
         }
         .exercise-container {
             background-color: #f3e5f5;
@@ -73,7 +73,7 @@
             border-left: 4px solid #f44336;
         }
         .nav-link.active {
-            background-color: #ff5722 !important;
+            background-color: #1976d2 !important;
             color: white !important;
         }
     </style>

--- a/docs/guide/database/oracle/oracle-learning-material-5.html
+++ b/docs/guide/database/oracle/oracle-learning-material-5.html
@@ -14,7 +14,7 @@
             padding-top: 56px;
         }
         .navbar {
-            background-color: #ff5722;
+            background-color: #1976d2;
         }
         .sidebar {
             position: sticky;
@@ -23,14 +23,14 @@
             overflow-y: auto;
         }
         .chapter-title {
-            color: #ff5722;
+            color: #1976d2;
             margin-top: 1.5rem;
             margin-bottom: 1rem;
-            border-bottom: 2px solid #ff5722;
+            border-bottom: 2px solid #1976d2;
             padding-bottom: 0.5rem;
         }
         .section-title {
-            color: #ff7043;
+            color: #42a5f5;
             margin-top: 1.2rem;
             margin-bottom: 0.8rem;
         }
@@ -45,11 +45,11 @@
             overflow-x: auto;
         }
         .quiz-container {
-            background-color: #fff3e0;
+            background-color: #e1f5fe;
             border-radius: 8px;
             padding: 1.5rem;
             margin: 1.5rem 0;
-            border-left: 4px solid #ff5722;
+            border-left: 4px solid #1976d2;
         }
         .exercise-container {
             background-color: #f3e5f5;
@@ -73,7 +73,7 @@
             border-left: 4px solid #f44336;
         }
         .nav-link.active {
-            background-color: #ff5722 !important;
+            background-color: #1976d2 !important;
             color: white !important;
         }
     </style>

--- a/docs/guide/database/oracle/oracle-learning-material-6.html
+++ b/docs/guide/database/oracle/oracle-learning-material-6.html
@@ -14,7 +14,7 @@
             padding-top: 56px;
         }
         .navbar {
-            background-color: #ff5722;
+            background-color: #1976d2;
         }
         .sidebar {
             position: sticky;
@@ -23,14 +23,14 @@
             overflow-y: auto;
         }
         .chapter-title {
-            color: #ff5722;
+            color: #1976d2;
             margin-top: 1.5rem;
             margin-bottom: 1rem;
-            border-bottom: 2px solid #ff5722;
+            border-bottom: 2px solid #1976d2;
             padding-bottom: 0.5rem;
         }
         .section-title {
-            color: #ff7043;
+            color: #42a5f5;
             margin-top: 1.2rem;
             margin-bottom: 0.8rem;
         }
@@ -45,11 +45,11 @@
             overflow-x: auto;
         }
         .quiz-container {
-            background-color: #fff3e0;
+            background-color: #e1f5fe;
             border-radius: 8px;
             padding: 1.5rem;
             margin: 1.5rem 0;
-            border-left: 4px solid #ff5722;
+            border-left: 4px solid #1976d2;
         }
         .exercise-container {
             background-color: #f3e5f5;
@@ -73,7 +73,7 @@
             border-left: 4px solid #f44336;
         }
         .nav-link.active {
-            background-color: #ff5722 !important;
+            background-color: #1976d2 !important;
             color: white !important;
         }
     </style>

--- a/docs/guide/database/oracle/oracle-learning-material-7.html
+++ b/docs/guide/database/oracle/oracle-learning-material-7.html
@@ -14,7 +14,7 @@
             padding-top: 56px;
         }
         .navbar {
-            background-color: #ff5722;
+            background-color: #1976d2;
         }
         .sidebar {
             position: sticky;
@@ -23,14 +23,14 @@
             overflow-y: auto;
         }
         .chapter-title {
-            color: #ff5722;
+            color: #1976d2;
             margin-top: 1.5rem;
             margin-bottom: 1rem;
-            border-bottom: 2px solid #ff5722;
+            border-bottom: 2px solid #1976d2;
             padding-bottom: 0.5rem;
         }
         .section-title {
-            color: #ff7043;
+            color: #42a5f5;
             margin-top: 1.2rem;
             margin-bottom: 0.8rem;
         }
@@ -45,11 +45,11 @@
             overflow-x: auto;
         }
         .quiz-container {
-            background-color: #fff3e0;
+            background-color: #e1f5fe;
             border-radius: 8px;
             padding: 1.5rem;
             margin: 1.5rem 0;
-            border-left: 4px solid #ff5722;
+            border-left: 4px solid #1976d2;
         }
         .exercise-container {
             background-color: #f3e5f5;
@@ -73,7 +73,7 @@
             border-left: 4px solid #f44336;
         }
         .nav-link.active {
-            background-color: #ff5722 !important;
+            background-color: #1976d2 !important;
             color: white !important;
         }
     </style>

--- a/docs/guide/database/oracle/oracle-learning-material-8.html
+++ b/docs/guide/database/oracle/oracle-learning-material-8.html
@@ -14,7 +14,7 @@
             padding-top: 56px;
         }
         .navbar {
-            background-color: #ff5722;
+            background-color: #1976d2;
         }
         .sidebar {
             position: sticky;
@@ -23,14 +23,14 @@
             overflow-y: auto;
         }
         .chapter-title {
-            color: #ff5722;
+            color: #1976d2;
             margin-top: 1.5rem;
             margin-bottom: 1rem;
-            border-bottom: 2px solid #ff5722;
+            border-bottom: 2px solid #1976d2;
             padding-bottom: 0.5rem;
         }
         .section-title {
-            color: #ff7043;
+            color: #42a5f5;
             margin-top: 1.2rem;
             margin-bottom: 0.8rem;
         }
@@ -45,11 +45,11 @@
             overflow-x: auto;
         }
         .quiz-container {
-            background-color: #fff3e0;
+            background-color: #e1f5fe;
             border-radius: 8px;
             padding: 1.5rem;
             margin: 1.5rem 0;
-            border-left: 4px solid #ff5722;
+            border-left: 4px solid #1976d2;
         }
         .exercise-container {
             background-color: #f3e5f5;
@@ -73,7 +73,7 @@
             border-left: 4px solid #f44336;
         }
         .nav-link.active {
-            background-color: #ff5722 !important;
+            background-color: #1976d2 !important;
             color: white !important;
         }
     </style>


### PR DESCRIPTION
## Summary
Oracle学習教材のカラーテーマをPL/SQL教材と統一感のある青系に変更しました。

## 変更内容
- **全8章のHTMLファイル**のカラーテーマを更新
- **統一されたデザインテーマ**でOracle関連技術として一貫性を確保
- **適切な差別化**でPL/SQLとOracleを区別しつつ統一感を維持

## 具体的な色の変更
 < /dev/null |  要素 | 変更前 (オレンジ系) | 変更後 (青系) |
|------|-------------------|--------------|
| ナビゲーションバー | `#ff5722` | `#1976d2` |
| 章タイトル | `#ff5722` | `#1976d2` |
| セクションタイトル | `#ff7043` | `#42a5f5` |
| クイズコンテナ背景 | `#fff3e0` | `#e1f5fe` |
| クイズコンテナボーダー | `#ff5722` | `#1976d2` |
| アクティブナビリンク | `#ff5722` | `#1976d2` |

## デザイン統一の効果
- 🎨 **統一感**: PL/SQL (`#1565c0`) とOracle (`#1976d2`) で青系テーマに統一
- 🔧 **差別化**: 微妙に異なる青色で技術領域を適切に区別
- 📚 **一貫性**: Oracle関連技術として視覚的な関連性を強化

## Test plan
- [ ] 全8章のHTMLファイルが新しい青系テーマで表示される
- [ ] ナビゲーション要素の色が適切に変更されている
- [ ] クイズコンテナの背景色とボーダー色が統一されている
- [ ] PL/SQL教材との視覚的統一感が確保されている

🤖 Generated with [Claude Code](https://claude.ai/code)