### PR TITLE
READMEの学習ガイドライン一覧を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 - **[JDBC学習ガイド](docs/guide/java-ecosystem/jdbc/README.md)** - JDBC基礎からパフォーマンスチューニングまで10ステップ
 - **[JSP/Servlet学習ガイド](docs/guide/java-ecosystem/jsp/README.md)** - JSP/Servlet基礎からMVCアーキテクチャまで10ステップ
 - **[Spring Framework学習ガイド](docs/guide/java-ecosystem/spring/README.md)** - Spring基礎からSecurity機能まで11ステップ
+- **[Struts 1.x学習ガイド](docs/guide/java-ecosystem/struts1/README.md)** - Apache Struts 1.x基礎からデプロイメントまで10章完成カリキュラム
 
 ### フロントエンド
 
@@ -110,10 +111,6 @@
 ### Office・自動化
 
 - **[VBA学習ガイド](docs/guide/office/vba/README.md)** - VBA基礎からExcel自動化まで10ステップ
-
-### データ分析
-
-- **[SAS学習ガイド](docs/guide/data-analytics/sas)** - SAS基本構造とデータ分析技術
 
 ---
 


### PR DESCRIPTION
## Summary
README.mdの学習ガイドライン一覧を最新の状態に更新しました。

### 🆕 追加項目
- **Struts 1.x学習ガイド** - Apache Struts 1.x基礎からデプロイメントまで10章完成カリキュラム
  - 新規作成されたカリキュラムをJavaエコシステムセクションに追加

### 🔧 修正項目
- **SAS学習ガイド記載を削除** - 実際にはREADME.mdファイルが存在しないため不整合を解消
- **フォーマット整理** - 余分な空行を削除し、統一性を向上

### 📋 現在の学習ガイドライン一覧
- **Javaエコシステム**: Java、JDBC、JSP/Servlet、Spring Framework、Struts 1.x（5個）
- **フロントエンド**: JavaScript初心者向け、JavaScript中級（2個）
- **データベース**: SQL、Oracle、PL/SQL（3個）
- **Office・自動化**: VBA（1個）

**合計**: 11個の学習ガイドライン

## Test plan
- [x] 全ガイドラインのREADME.mdファイル存在確認
- [x] リンクパス検証
- [x] 説明文の統一性確認
- [x] セクション分類の適切性確認

🤖 Generated with [Claude Code](https://claude.ai/code)