### PR TITLE
SASチートシートにPROC SQLセクションを追加

### DIFF
--- a/docs/cheatsheet/systems-environments/sas-cheatsheet.html
+++ b/docs/cheatsheet/systems-environments/sas-cheatsheet.html
@@ -610,6 +610,10 @@ RUN;</div>
                             <th>機能</th>
                         </tr>
                         <tr>
+                            <td>PROC SQL</td>
+                            <td>SQLライクなデータクエリ・操作</td>
+                        </tr>
+                        <tr>
                             <td>PROC MEANS</td>
                             <td>基本統計量の算出（平均、標準偏差など）</td>
                         </tr>
@@ -651,6 +655,106 @@ PROC MEANS DATA=class MEAN MEDIAN STD MIN MAX;
    CLASS gender;
    TITLE 'Summary Statistics by Gender';
 RUN;</div>
+                    </div>
+                </div>
+
+                <div class="card">
+                    <h2 class="section-title">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M9 22H15C20 22 22 20 22 15V9C22 4 20 2 15 2H9C4 2 2 4 2 9V15C2 20 4 22 9 22Z" stroke="#593C47" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                            <path d="M15.5 9.5H8.5" stroke="#F25C05" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                            <path d="M15.5 12H8.5" stroke="#F25C05" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                            <path d="M15.5 14.5H8.5" stroke="#F25C05" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+                        </svg>
+                        PROC SQL - SQLライクなデータ処理
+                    </h2>
+
+                    <p class="body-text">PROC SQLを使用すると、SQLに似た構文でSASデータセットを操作できます。</p>
+
+                    <div class="icon-text">
+                        <span class="emoji">🔍</span>
+                        <div>
+                            <strong>基本構文</strong>: SELECT文によるデータ抽出
+                        </div>
+                    </div>
+
+                    <div class="code-block">/* 基本的なSELECT文 */
+PROC SQL;
+   SELECT name, age, height
+   FROM class
+   WHERE age > 18
+   ORDER BY age;
+QUIT;</div>
+
+                    <div class="icon-text">
+                        <span class="emoji">🔗</span>
+                        <div>
+                            <strong>JOIN操作</strong>: 複数のテーブルを結合
+                        </div>
+                    </div>
+
+                    <div class="code-block">/* INNER JOINの例 */
+PROC SQL;
+   SELECT a.name, a.age, b.score
+   FROM students a
+   INNER JOIN grades b
+   ON a.id = b.student_id;
+QUIT;</div>
+
+                    <div class="icon-text">
+                        <span class="emoji">📊</span>
+                        <div>
+                            <strong>集計とグループ化</strong>: GROUP BYとHAVING句
+                        </div>
+                    </div>
+
+                    <div class="code-block">/* グループ別集計 */
+PROC SQL;
+   SELECT gender, 
+          COUNT(*) AS count,
+          AVG(height) AS avg_height,
+          MAX(weight) AS max_weight
+   FROM class
+   GROUP BY gender
+   HAVING count > 5;
+QUIT;</div>
+
+                    <div class="icon-text">
+                        <span class="emoji">🆕</span>
+                        <div>
+                            <strong>テーブル作成</strong>: CREATE TABLE AS
+                        </div>
+                    </div>
+
+                    <div class="code-block">/* 新しいデータセットの作成 */
+PROC SQL;
+   CREATE TABLE adults AS
+   SELECT name, age, 
+          CASE 
+             WHEN age < 30 THEN 'Young Adult'
+             WHEN age < 50 THEN 'Middle Age'
+             ELSE 'Senior'
+          END AS age_group
+   FROM class
+   WHERE age >= 18;
+QUIT;</div>
+
+                    <div class="note">
+                        PROC SQLでは標準SQLの多くの機能が使用できます。サブクエリ、UNION、EXISTS句なども利用可能です。
+                    </div>
+
+                    <div class="example-section">
+                        <div class="example-title">実用例 - 条件付き更新:</div>
+                        <div class="code-block">/* データセットの更新 */
+PROC SQL;
+   UPDATE class
+   SET category = 
+       CASE 
+          WHEN age < 18 THEN 'Minor'
+          WHEN age >= 65 THEN 'Senior'
+          ELSE 'Adult'
+       END;
+QUIT;</div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- SASチートシートにPROC SQLの包括的なセクションを追加
- 統計プロシージャ一覧にもPROC SQLを追加

## 追加内容
- **基本構文**: SELECT、WHERE、ORDER BY文の使用例
- **JOIN操作**: INNER JOINによるテーブル結合の説明と例
- **集計とグループ化**: GROUP BY、HAVING句による集計処理
- **テーブル作成**: CREATE TABLE AS構文の使用方法
- **データ更新**: UPDATE文とCASE文による条件付きデータ更新

## Test plan
- [x] HTMLファイルが適切に更新されていることを確認
- [x] 既存のデザインとスタイルに統合されていることを確認
- [x] コード例が正しいSAS構文であることを確認
- [x] 統計プロシージャ一覧にPROC SQLが追加されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)