### PR TITLE
Oracle学習教材の最終調整: データ永続化セクション削除とlearner接続設定

### DIFF
--- a/docs/guide/database/oracle/oracle-learning-material-2.html
+++ b/docs/guide/database/oracle/oracle-learning-material-2.html
@@ -297,44 +297,7 @@ docker volume ls
 # データボリュームの削除
 docker volume rm oracle-data</code>
 
-                    <h3 class="section-title">2.8 データの永続化設定</h3>
-                    <p>コンテナを削除してもデータが保持されるよう、適切な永続化設定を確認します：</p>
-
-                    <div class="exercise-container">
-                        <h5>実習 2-6: データ永続化の確認</h5>
-                        <code># 現在のボリュームマウント状況を確認 (PowerShell)
-docker inspect oracle-xe | Select-String -Pattern "Mounts" -Context 0,10
-
-# 現在のボリュームマウント状況を確認 (Command Prompt)
-docker inspect oracle-xe | findstr /C:"Mounts"
-
-# ボリュームの詳細情報を確認
-docker volume inspect oracle-data
-
-# テストデータを作成 (PowerShell)
-@"
-CREATE TABLE test_persistence (
-    id NUMBER,
-    message VARCHAR2(100)
-);
-INSERT INTO test_persistence VALUES (1, 'データ永続化テスト');
-COMMIT;
-EXIT;
-"@ | docker exec -i oracle-xe sqlplus learner/learner123@localhost:1521/XE
-
-# テストデータを作成 (Command Prompt)
-echo CREATE TABLE test_persistence ( > temp_sql.txt
-echo     id NUMBER, >> temp_sql.txt
-echo     message VARCHAR2(100) >> temp_sql.txt
-echo ); >> temp_sql.txt
-echo INSERT INTO test_persistence VALUES (1, 'データ永続化テスト'); >> temp_sql.txt
-echo COMMIT; >> temp_sql.txt
-echo EXIT; >> temp_sql.txt
-docker exec -i oracle-xe sqlplus learner/learner123@localhost:1521/XE < temp_sql.txt
-del temp_sql.txt</code>
-                    </div>
-
-                    <h3 class="section-title">2.9 トラブルシューティング</h3>
+                    <h3 class="section-title">2.8 トラブルシューティング</h3>
                     <h4>よくある問題と解決方法</h4>
                     
                     <div class="table-responsive">

--- a/docs/guide/database/oracle/oracle-learning-material-3.html
+++ b/docs/guide/database/oracle/oracle-learning-material-3.html
@@ -217,13 +217,12 @@
                             <li>接続情報を入力：
                                 <ul>
                                     <li><strong>接続名</strong>: Oracle XE Local</li>
-                                    <li><strong>ユーザー名</strong>: sys</li>
-                                    <li><strong>パスワード</strong>: Password123</li>
+                                    <li><strong>ユーザー名</strong>: learner</li>
+                                    <li><strong>パスワード</strong>: learner123</li>
                                     <li><strong>パスワードの保存</strong>: チェック（任意）</li>
                                     <li><strong>ホスト名</strong>: localhost</li>
                                     <li><strong>ポート</strong>: 1521</li>
                                     <li><strong>SID</strong>: XE</li>
-                                    <li><strong>ロール</strong>: SYSDBA</li>
                                 </ul>
                             </li>
                             <li>「テスト」ボタンをクリックして接続確認</li>
@@ -236,16 +235,16 @@
                         <ul>
                             <li><strong>TNS-12541</strong>: Dockerコンテナが起動しているか確認（docker ps）</li>
                             <li><strong>ORA-01017</strong>: ユーザー名・パスワードを再確認</li>
-                            <li><strong>ORA-28009</strong>: ロールがSYSDBAに設定されているか確認</li>
+                            <li><strong>ユーザー不存在</strong>: learnerユーザーが作成されているか確認</li>
                             <li><strong>タイムアウト</strong>: ホスト名・ポート番号を確認</li>
                             <li><strong>接続失敗</strong>: SIDがXEに設定されているか確認</li>
                         </ul>
                         
-                        <h6>接続確認コマンド</h6>
-                        <p>コンテナ内でのサービス名確認：</p>
+                        <h6>learnerユーザー作成確認</h6>
+                        <p>第2章でlearnerユーザーが正しく作成されているか確認：</p>
                         <code>docker exec -it oracle-xe sqlplus sys/Password123@localhost:1521/XE as sysdba
-SQL> SELECT name FROM v$database;
-SQL> SHOW PARAMETER service_names;</code>
+SQL> SELECT username FROM dba_users WHERE username = 'LEARNER';
+SQL> exit;</code>
                     </div>
 
                     <h3 class="section-title">3.6 SQLワークシートの基本操作</h3>


### PR DESCRIPTION
## Summary
- データの永続化セクション(2.8)を削除してシンプル化
- SQL Developer接続設定をlearner/learner123に統一
- 学習者向けの適切な設定に調整

## Changes Made
- **第2章**: 
  - 2.8 データの永続化設定セクションを削除
  - Dockerボリューム設定は起動時に既に適用済みのため不要
  - セクション番号調整（2.9→2.8）

- **第3章**:
  - SQL Developer接続設定をsys/SYSDBAからlearner/learner123に変更
  - 一般ユーザー向けの適切な設定に統一
  - エラー対処法をlearnerユーザー向けに調整

## Benefits
- 内容がシンプルで分かりやすくなった
- 学習者が混乱しやすい部分を削除
- 統一された接続設定で一貫性向上

## Test plan
- [ ] 修正されたHTML ファイルの表示確認
- [ ] learner/learner123でのSQL Developer接続確認
- [ ] GitHub Pagesでの表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)