### PR TITLE
Oracle学習教材: PDB接続対応でORA-65096エラーを修正

### DIFF
--- a/docs/guide/database/oracle/oracle-learning-material-2.html
+++ b/docs/guide/database/oracle/oracle-learning-material-2.html
@@ -256,13 +256,19 @@ SQL> SELECT name FROM v$database;
 SQL> exit;</code>
                     </div>
 
-                    <h3 class="section-title">2.6 サンプルユーザーの作成</h3>
-                    <p>学習用のサンプルユーザーを作成しましょう：</p>
+                    <h3 class="section-title">2.6 PDBとサンプルユーザーの作成</h3>
+                    <p>Oracle XEはマルチテナント・アーキテクチャのため、PDB（Pluggable Database）に接続してユーザーを作成します：</p>
 
                     <div class="exercise-container">
-                        <h5>実習 2-5: サンプルユーザーの作成</h5>
+                        <h5>実習 2-5: PDB確認とサンプルユーザーの作成</h5>
                         <code># SYSユーザーでSQLPlusに接続
 docker exec -it oracle-xe sqlplus sys/Password123@localhost:1521/XE as sysdba
+
+# PDB（Pluggable Database）の確認
+SQL> SHOW PDBS;
+
+# XEPDB1に接続
+SQL> ALTER SESSION SET CONTAINER = XEPDB1;
 
 # 学習用ユーザーを作成
 SQL> CREATE USER learner IDENTIFIED BY learner123;
@@ -271,9 +277,21 @@ SQL> ALTER USER learner DEFAULT TABLESPACE USERS;
 SQL> ALTER USER learner QUOTA UNLIMITED ON USERS;
 
 # 作成したユーザーで接続テスト
-SQL> CONNECT learner/learner123@localhost:1521/XE
+SQL> CONNECT learner/learner123@localhost:1521/XEPDB1
 SQL> SELECT USER FROM DUAL;
 SQL> exit;</code>
+                        
+                        <div class="highlight">
+                            <h6>マルチテナント・アーキテクチャについて</h6>
+                            <p>
+                                Oracle 12c以降では、CDB（Container Database）とPDB（Pluggable Database）の構造になっています。
+                                ユーザーはPDB内に作成する必要があります。
+                            </p>
+                            <ul>
+                                <li><strong>CDB</strong>: XE（コンテナデータベース）</li>
+                                <li><strong>PDB</strong>: XEPDB1（プラガブルデータベース）</li>
+                            </ul>
+                        </div>
                     </div>
 
                     <h3 class="section-title">2.7 コンテナ管理の基本操作</h3>

--- a/docs/guide/database/oracle/oracle-learning-material-3.html
+++ b/docs/guide/database/oracle/oracle-learning-material-3.html
@@ -222,7 +222,8 @@
                                     <li><strong>パスワードの保存</strong>: チェック（任意）</li>
                                     <li><strong>ホスト名</strong>: localhost</li>
                                     <li><strong>ポート</strong>: 1521</li>
-                                    <li><strong>SID</strong>: XE</li>
+                                    <li><strong>接続タイプ</strong>: 「サービス名」を選択</li>
+                                    <li><strong>サービス名</strong>: XEPDB1</li>
                                 </ul>
                             </li>
                             <li>「テスト」ボタンをクリックして接続確認</li>
@@ -237,12 +238,13 @@
                             <li><strong>ORA-01017</strong>: ユーザー名・パスワードを再確認</li>
                             <li><strong>ユーザー不存在</strong>: learnerユーザーが作成されているか確認</li>
                             <li><strong>タイムアウト</strong>: ホスト名・ポート番号を確認</li>
-                            <li><strong>接続失敗</strong>: SIDがXEに設定されているか確認</li>
+                            <li><strong>接続失敗</strong>: サービス名がXEPDB1に設定されているか確認</li>
                         </ul>
                         
                         <h6>learnerユーザー作成確認</h6>
                         <p>第2章でlearnerユーザーが正しく作成されているか確認：</p>
                         <code>docker exec -it oracle-xe sqlplus sys/Password123@localhost:1521/XE as sysdba
+SQL> ALTER SESSION SET CONTAINER = XEPDB1;
 SQL> SELECT username FROM dba_users WHERE username = 'LEARNER';
 SQL> exit;</code>
                     </div>


### PR DESCRIPTION
## Summary
Oracle XEのマルチテナント・アーキテクチャに対応し、ORA-65096エラーを解決する修正を行いました。

## Problem
Oracle Database XEでユーザー作成時に以下のエラーが発生：
```
ORA-65096: invalid common user or role name
```

## Root Cause
Oracle 12c以降のマルチテナント・アーキテクチャでは、ユーザーはPDB（Pluggable Database）内に作成する必要があります。

## Solution
### 第2章の修正
- **PDB確認**: `SHOW PDBS;`でXEPDB1を確認
- **PDB接続**: `ALTER SESSION SET CONTAINER = XEPDB1;`
- **ユーザー作成**: XEPDB1内でlearnerユーザーを作成
- **接続テスト**: `CONNECT learner/learner123@localhost:1521/XEPDB1`
- **説明追加**: マルチテナント・アーキテクチャ（CDB/PDB）の概要

### 第3章の修正
- **SQL Developer接続設定**: SID → サービス名XEPDB1に変更
- **エラー対処法**: XEPDB1での確認コマンドに更新

## Technical Details
- **CDB**: XE（Container Database）
- **PDB**: XEPDB1（Pluggable Database）
- **接続文字列**: `localhost:1521/XEPDB1`

## Benefits
- ORA-65096エラーの完全解決
- Oracle 12c以降の標準アーキテクチャに準拠
- 学習者にとって理解しやすい構造説明

## Test plan
- [ ] 修正されたHTML ファイルの表示確認
- [ ] XEPDB1でのlearnerユーザー作成確認
- [ ] SQL DeveloperでのXEPDB1接続確認
- [ ] GitHub Pagesでの表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)