### PR TITLE
Strutsチュートリアル: struts-1.3.10-bin.zipをstruts-1.3.10-all.zipに修正

### DIFF
--- a/docs/tutorial/struts1/step1-environment-setup.html
+++ b/docs/tutorial/struts1/step1-environment-setup.html
@@ -306,8 +306,8 @@
                             <li><strong>Apache Struts公式サイト</strong>にアクセス：
                                 <a href="https://archive.apache.org/dist/struts/binaries/" target="_blank">https://archive.apache.org/dist/struts/binaries/</a>
                             </li>
-                            <li><strong>struts-1.3.10-bin.zip</strong>をクリックしてダウンロード</li>
-                            <li>ダウンロードした<strong>struts-1.3.10-bin.zip</strong>を適当なフォルダに解凍</li>
+                            <li><strong>struts-1.3.10-all.zip</strong>をクリックしてダウンロード</li>
+                            <li>ダウンロードした<strong>struts-1.3.10-all.zip</strong>を適当なフォルダに解凍</li>
                             <li>解凍されたフォルダ内の<strong>webapps</strong>フォルダを開く</li>
                             <li><strong>struts-blank.war</strong>ファイルを見つける</li>
                             <li>このファイルを分かりやすい場所（例: デスクトップ）にコピー</li>
@@ -315,7 +315,7 @@
                         
                         <div class="highlight">
                             <h6>アーカイブ構成の確認</h6>
-                            <p>struts-1.3.10-bin.zipを解凍すると以下のような構成になっています：</p>
+                            <p>struts-1.3.10-all.zipを解凍すると以下のような構成になっています：</p>
                             <pre><code>struts-1.3.10/
 ├── lib/                      ← Strutsライブラリファイル
 ├── webapps/


### PR DESCRIPTION
## Summary
- step1-environment-setup.htmlにおいて、struts-blank.war取得に使用するアーカイブファイル名を修正
- struts-1.3.10-bin.zip → struts-1.3.10-all.zipに統一

## Changes
- ダウンロード手順の修正
- 解凍手順の修正  
- アーカイブ構成説明の修正

## Test plan
- [ ] 修正されたHTMLファイルの表示確認
- [ ] リンク切れやタイポがないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)