### PR TITLE
PL/SQL学習教材: 第1章に学習用環境準備を追加

### DIFF
--- a/docs/guide/database/plsql/plsql-learning-material-1.html
+++ b/docs/guide/database/plsql/plsql-learning-material-1.html
@@ -197,6 +197,112 @@ END;
 /</code>
                     </div>
 
+                    <h3 class="section-title">1.5 学習用環境準備</h3>
+                    <p>PL/SQL学習教材のコード例を実行するために、サンプルテーブルとデータを準備しましょう。</p>
+                    
+                    <div class="highlight">
+                        <h5>重要</h5>
+                        <p>この学習教材では、Oracle HRスキーマのemployeesテーブルとdepartmentsテーブルを使用した例が多数含まれています。
+                        以下のスクリプトを実行して、学習用のサンプルデータを準備してください。</p>
+                    </div>
+
+                    <div class="exercise-container">
+                        <h5>実習 1-2: 学習用テーブル作成</h5>
+                        <p>以下のスクリプトをOracle環境で実行してください：</p>
+                        
+                        <h6>1. テーブル作成</h6>
+                        <code>-- 部署テーブル
+CREATE TABLE departments (
+    department_id NUMBER PRIMARY KEY,
+    department_name VARCHAR2(50) NOT NULL,
+    manager_id NUMBER,
+    location VARCHAR2(50)
+);
+
+-- 従業員テーブル
+CREATE TABLE employees (
+    employee_id NUMBER PRIMARY KEY,
+    first_name VARCHAR2(50) NOT NULL,
+    last_name VARCHAR2(50) NOT NULL,
+    email VARCHAR2(100),
+    phone_number VARCHAR2(20),
+    hire_date DATE DEFAULT SYSDATE,
+    job_title VARCHAR2(50),
+    salary NUMBER(8,2),
+    commission_pct NUMBER(2,2),
+    manager_id NUMBER,
+    department_id NUMBER,
+    last_update_date DATE DEFAULT SYSDATE,
+    CONSTRAINT fk_emp_dept FOREIGN KEY (department_id) 
+        REFERENCES departments(department_id)
+);
+
+-- シーケンス作成
+CREATE SEQUENCE emp_seq START WITH 1000 INCREMENT BY 1;
+CREATE SEQUENCE dept_seq START WITH 100 INCREMENT BY 10;</code>
+
+                        <h6>2. サンプルデータ挿入</h6>
+                        <code>-- 部署データ
+INSERT INTO departments VALUES (10, 'Administration', 200, 'Seattle');
+INSERT INTO departments VALUES (20, 'Marketing', 201, 'Toronto');
+INSERT INTO departments VALUES (30, 'Purchasing', 114, 'Seattle');
+INSERT INTO departments VALUES (40, 'Human Resources', 203, 'London');
+INSERT INTO departments VALUES (50, 'Shipping', 121, 'South San Francisco');
+INSERT INTO departments VALUES (60, 'IT', 103, 'Southlake');
+INSERT INTO departments VALUES (90, 'Executive', 100, 'Seattle');
+
+-- 従業員データ（全12カラムの値を指定）
+INSERT INTO employees VALUES (100, 'Steven', 'King', 'sking@company.com', '515.123.4567', DATE '2003-06-17', 'President', 24000, NULL, NULL, 90, SYSDATE);
+INSERT INTO employees VALUES (101, 'Neena', 'Kochhar', 'nkochhar@company.com', '515.123.4568', DATE '2005-09-21', 'Administration Vice President', 17000, NULL, 100, 90, SYSDATE);
+INSERT INTO employees VALUES (102, 'Lex', 'De Haan', 'ldehaan@company.com', '515.123.4569', DATE '2001-01-13', 'Administration Vice President', 17000, NULL, 100, 90, SYSDATE);
+INSERT INTO employees VALUES (103, 'Alexander', 'Hunold', 'ahunold@company.com', '590.423.4567', DATE '2006-01-03', 'IT Manager', 9000, NULL, 102, 60, SYSDATE);
+INSERT INTO employees VALUES (104, 'Bruce', 'Ernst', 'bernst@company.com', '590.423.4568', DATE '2007-05-21', 'IT Programmer', 6000, NULL, 103, 60, SYSDATE);
+INSERT INTO employees VALUES (105, 'David', 'Austin', 'daustin@company.com', '590.423.4569', DATE '2005-06-25', 'IT Programmer', 4800, NULL, 103, 60, SYSDATE);
+INSERT INTO employees VALUES (106, 'Valli', 'Pataballa', 'vpatabal@company.com', '590.423.4560', DATE '2006-02-05', 'IT Programmer', 4800, NULL, 103, 60, SYSDATE);
+INSERT INTO employees VALUES (107, 'Diana', 'Lorentz', 'dlorentz@company.com', '590.423.5567', DATE '2007-02-07', 'IT Programmer', 4200, NULL, 103, 60, SYSDATE);
+
+-- 部署10用の従業員
+INSERT INTO employees VALUES (200, 'Jennifer', 'Whalen', 'jwhalen@company.com', '515.123.4444', DATE '2003-09-17', 'Administration Assistant', 4400, NULL, 101, 10, SYSDATE);
+INSERT INTO employees VALUES (203, 'Susan', 'Mavris', 'smavris@company.com', '515.123.7777', DATE '2002-06-07', 'HR Representative', 6500, NULL, 101, 10, SYSDATE);
+INSERT INTO employees VALUES (204, 'Hermann', 'Baer', 'hbaer@company.com', '515.123.8888', DATE '2002-06-07', 'PR Representative', 10000, NULL, 101, 10, SYSDATE);
+
+-- その他の部署の従業員
+INSERT INTO employees VALUES (201, 'Michael', 'Hartstein', 'mhartste@company.com', '515.123.5555', DATE '2004-02-17', 'Marketing Manager', 13000, NULL, 100, 20, SYSDATE);
+INSERT INTO employees VALUES (202, 'Pat', 'Smith', 'psmith@company.com', '603.123.6666', DATE '2005-08-17', 'HR Representative', 6000, NULL, 101, 40, SYSDATE);
+
+COMMIT;</code>
+
+                        <h6>3. 動作確認</h6>
+                        <code>-- データ確認
+SELECT 'departments' as table_name, COUNT(*) as record_count FROM departments
+UNION ALL
+SELECT 'employees', COUNT(*) FROM employees;
+
+-- 部署別従業員数
+SELECT d.department_name, COUNT(e.employee_id) as emp_count
+FROM departments d
+LEFT JOIN employees e ON d.department_id = e.department_id
+GROUP BY d.department_name
+ORDER BY emp_count DESC;</code>
+
+                        <h6>期待される結果</h6>
+                        <ul>
+                            <li>departments テーブル: 7件のレコード</li>
+                            <li>employees テーブル: 13件のレコード</li>
+                            <li>部署10（Administration）に3名の従業員が配属</li>
+                        </ul>
+                        
+                        <div class="highlight">
+                            <h6>重要な注意事項</h6>
+                            <ul>
+                                <li>このスクリプトは学習目的で作成されており、本番環境での使用は避けてください</li>
+                                <li>既存のテーブルと名前が競合する場合は、テーブル名を変更するか、別のスキーマで実行してください</li>
+                                <li>第2章〜第6章、第8章〜第10章のコード例は、このサンプルデータを前提として作成されています</li>
+                                <li>第7章（トリガー）で使用する監査テーブルは、該当章で個別に作成手順を説明します</li>
+                            </ul>
+                        </div>
+                    </div>
+
                     <div class="quiz-container">
                         <h5>理解度確認クイズ</h5>
                         <ol>


### PR DESCRIPTION
## Summary
- PL/SQL学習教材第1章に学習用環境準備セクション（1.5）を新規追加
- 実習1-2として学習用テーブル作成スクリプトを提供
- INSERT文のORA-00947エラー（値の個数不足）を修正

## 主な変更点
- **新セクション追加**: 1.5 学習用環境準備
- **DDL修正**: INSERT文で12カラム分の値を正しく指定
- **学習フロー最適化**: 第7章のトリガー用テーブルは該当章で個別作成
- **サンプルデータ**: departments（7件）、employees（13件）を提供

## Test plan
- [ ] HTMLファイルの表示確認
- [ ] 提供されたDDLスクリプトの実行確認
- [ ] 学習教材の他の章との整合性確認

🤖 Generated with [Claude Code](https://claude.ai/code)