### PR TITLE
fix: ダークモードで色付きボックス内テキストが判読不能になる問題を修正

### DIFF
--- a/docs/guide/development-processes/claude-code/styles.css
+++ b/docs/guide/development-processes/claude-code/styles.css
@@ -658,6 +658,36 @@ html.dark [class~="from-indigo-50"], html.dark [class~="from-violet-50"], html.d
   background: linear-gradient(165deg, rgba(139, 92, 246, .14), rgba(139, 92, 246, .03)), var(--card) !important;
 }
 
+/* ダーク: 入れ子の色付きボックス／チップ／番号バッジ（-100 / -200）。
+   -50 と同じ色名ベースで網羅し、明色背景×明色文字（判読不能）を構造的に防ぐ。
+   -100 はボックス用、-200 はチップ／バッジ用に少し濃いめのティント。
+   code.bg-*-100 と番号バッジ .bg-purple-200 はより詳細度の高い既存規則が優先される。 */
+/* 橙黄系（orange/amber/yellow） */
+html.dark .bg-orange-100, html.dark .bg-amber-100, html.dark .bg-yellow-100 {
+  background: linear-gradient(165deg, rgba(245, 158, 11, .20), rgba(245, 158, 11, .06)), var(--card) !important;
+}
+html.dark .bg-orange-200, html.dark .bg-amber-200, html.dark .bg-yellow-200 { background: rgba(245, 158, 11, .24) !important; }
+/* 赤系（red/rose/pink） */
+html.dark .bg-red-100, html.dark .bg-rose-100, html.dark .bg-pink-100 {
+  background: linear-gradient(165deg, rgba(244, 63, 94, .20), rgba(244, 63, 94, .06)), var(--card) !important;
+}
+html.dark .bg-red-200, html.dark .bg-rose-200, html.dark .bg-pink-200 { background: rgba(244, 63, 94, .24) !important; }
+/* 緑系（green/emerald/teal/lime） */
+html.dark .bg-green-100, html.dark .bg-emerald-100, html.dark .bg-teal-100, html.dark .bg-lime-100 {
+  background: linear-gradient(165deg, rgba(16, 185, 129, .20), rgba(16, 185, 129, .06)), var(--card) !important;
+}
+html.dark .bg-green-200, html.dark .bg-emerald-200, html.dark .bg-teal-200, html.dark .bg-lime-200 { background: rgba(16, 185, 129, .24) !important; }
+/* 青系（blue/cyan/sky） */
+html.dark .bg-blue-100, html.dark .bg-cyan-100, html.dark .bg-sky-100 {
+  background: linear-gradient(165deg, rgba(6, 182, 212, .20), rgba(6, 182, 212, .06)), var(--card) !important;
+}
+html.dark .bg-blue-200, html.dark .bg-cyan-200, html.dark .bg-sky-200 { background: rgba(6, 182, 212, .24) !important; }
+/* 紫系（indigo/violet/purple/fuchsia）。.bg-purple-200 は番号バッジの既存規則を尊重し除外 */
+html.dark .bg-indigo-100, html.dark .bg-violet-100, html.dark .bg-purple-100, html.dark .bg-fuchsia-100 {
+  background: linear-gradient(165deg, rgba(139, 92, 246, .20), rgba(139, 92, 246, .06)), var(--card) !important;
+}
+html.dark .bg-indigo-200, html.dark .bg-violet-200, html.dark .bg-fuchsia-200 { background: rgba(139, 92, 246, .24) !important; }
+
 /* ダーク: カード内テキスト色を読みやすく（色名ベースで網羅。-700/-800/-900） */
 html.dark .text-amber-700, html.dark .text-amber-800, html.dark .text-amber-900,
 html.dark .text-orange-600, html.dark .text-orange-700, html.dark .text-orange-800, html.dark .text-orange-900,

--- a/templates/v3/html/styles.css
+++ b/templates/v3/html/styles.css
@@ -658,6 +658,36 @@ html.dark [class~="from-indigo-50"], html.dark [class~="from-violet-50"], html.d
   background: linear-gradient(165deg, rgba(139, 92, 246, .14), rgba(139, 92, 246, .03)), var(--card) !important;
 }
 
+/* ダーク: 入れ子の色付きボックス／チップ／番号バッジ（-100 / -200）。
+   -50 と同じ色名ベースで網羅し、明色背景×明色文字（判読不能）を構造的に防ぐ。
+   -100 はボックス用、-200 はチップ／バッジ用に少し濃いめのティント。
+   code.bg-*-100 と番号バッジ .bg-purple-200 はより詳細度の高い既存規則が優先される。 */
+/* 橙黄系（orange/amber/yellow） */
+html.dark .bg-orange-100, html.dark .bg-amber-100, html.dark .bg-yellow-100 {
+  background: linear-gradient(165deg, rgba(245, 158, 11, .20), rgba(245, 158, 11, .06)), var(--card) !important;
+}
+html.dark .bg-orange-200, html.dark .bg-amber-200, html.dark .bg-yellow-200 { background: rgba(245, 158, 11, .24) !important; }
+/* 赤系（red/rose/pink） */
+html.dark .bg-red-100, html.dark .bg-rose-100, html.dark .bg-pink-100 {
+  background: linear-gradient(165deg, rgba(244, 63, 94, .20), rgba(244, 63, 94, .06)), var(--card) !important;
+}
+html.dark .bg-red-200, html.dark .bg-rose-200, html.dark .bg-pink-200 { background: rgba(244, 63, 94, .24) !important; }
+/* 緑系（green/emerald/teal/lime） */
+html.dark .bg-green-100, html.dark .bg-emerald-100, html.dark .bg-teal-100, html.dark .bg-lime-100 {
+  background: linear-gradient(165deg, rgba(16, 185, 129, .20), rgba(16, 185, 129, .06)), var(--card) !important;
+}
+html.dark .bg-green-200, html.dark .bg-emerald-200, html.dark .bg-teal-200, html.dark .bg-lime-200 { background: rgba(16, 185, 129, .24) !important; }
+/* 青系（blue/cyan/sky） */
+html.dark .bg-blue-100, html.dark .bg-cyan-100, html.dark .bg-sky-100 {
+  background: linear-gradient(165deg, rgba(6, 182, 212, .20), rgba(6, 182, 212, .06)), var(--card) !important;
+}
+html.dark .bg-blue-200, html.dark .bg-cyan-200, html.dark .bg-sky-200 { background: rgba(6, 182, 212, .24) !important; }
+/* 紫系（indigo/violet/purple/fuchsia）。.bg-purple-200 は番号バッジの既存規則を尊重し除外 */
+html.dark .bg-indigo-100, html.dark .bg-violet-100, html.dark .bg-purple-100, html.dark .bg-fuchsia-100 {
+  background: linear-gradient(165deg, rgba(139, 92, 246, .20), rgba(139, 92, 246, .06)), var(--card) !important;
+}
+html.dark .bg-indigo-200, html.dark .bg-violet-200, html.dark .bg-fuchsia-200 { background: rgba(139, 92, 246, .24) !important; }
+
 /* ダーク: カード内テキスト色を読みやすく（色名ベースで網羅。-700/-800/-900） */
 html.dark .text-amber-700, html.dark .text-amber-800, html.dark .text-amber-900,
 html.dark .text-orange-600, html.dark .text-orange-700, html.dark .text-orange-800, html.dark .text-orange-900,


### PR DESCRIPTION
## 概要
- ダークモード時に、色付きの入れ子ボックス・チップ・番号バッジ内のテキストが判読不能になる問題を修正
- 対象: Claude Code 学習ガイドの共通CSS、および再発防止のためテンプレート(`templates/v3/html/styles.css`)

## 変更理由
- ダークモードのCSSは `bg-{color}-50`(外側カード)を暗色サーフェスへ remap し、テキスト色 `text-{color}-900` 等を明色へ remap する
- しかし入れ子ボックス `bg-{color}-100` とチップ／番号バッジ `bg-{color}-200` は remap 対象から漏れており、明色背景のまま残っていた
- 結果として「明色背景 × 明色文字」となり判読不能化していた（報告のあった「よくある問題と対処」「ゴール」ボックス、`Esc` / `claude --continue` チップ、5.2 のコード例ボックスなど）
- `-50` と同じ「色名ベースで網羅」する方針に合わせ、`bg-{color}-100`（ボックス用）と `bg-{color}-200`（チップ／バッジ用に少し濃いめ）の暗色ティント remap 規則を追加した
- インラインコード `code.bg-*-100` と番号バッジ `.bg-purple-200` は、詳細度の高い既存規則を優先させ見た目を温存

## テスト / 確認
- CSS詳細度の検証: 追加した `html.dark .bg-*-100` (0,2,1) は既存の `html.dark code.bg-*-100` (0,2,2) に負け、`.bg-purple-200` は `-200` 規則から除外しているため、コードチップ・番号バッジの既存スタイルは不変であることを確認
- 影響箇所のマークアップ確認: 章3「よくある問題と対処」(`bg-orange-100`)・「ゴール」(`bg-purple-100`)、章4 `Esc`/`--continue` チップ(`bg-blue-200`)、章5「5.2」コード例ボックス(`bg-emerald-100`/`bg-blue-100`) が対象規則でカバーされることを確認
- 注: 本環境にはブラウザ実機確認手段がないため、描画QA(`/docs-browser-review`)は未実施

## 注意事項
- 本件はテンプレート由来の共通バグのため、他カテゴリの既存ガイドにコピーされた `styles.css` にも同様の問題が残っている可能性がある。今回は報告対象（Claude Code 教材）とテンプレートのみに修正を限定している。他教材への一括展開が必要な場合は別途対応する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDQ82SfKikUZi26RGxQgY7)_